### PR TITLE
MLFlow entry-points and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore local execution directories
 .workdir
 .yadage
+mlruns
 
 # Ignore any macOS files
 **/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 FROM madminertool/docker-madminer:latest
 
 
+#### Install binary dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
+
 #### Set working directory
 WORKDIR /madminer
 
@@ -10,7 +14,7 @@ WORKDIR /madminer
 COPY code ./code
 COPY data ./data
 COPY scripts ./scripts
-COPY requirements.txt .
+COPY MLproject requirements.txt ./
 
 
 # Install Python3 dependencies

--- a/MLFLOW.md
+++ b/MLFLOW.md
@@ -1,0 +1,118 @@
+# MLFlow ♻️
+
+
+## About
+This explanation guide covers the introduction of [MLFlow][mlflow-website] into
+certain steps of the workflow.
+
+
+## Features
+MLFlow provides a simple way to:
+
+- Iterate over hyper-parameters.
+- Keep track of consecutive ML experiment runs.
+- Keep track of ML models evolution over time.
+
+
+## Specification
+There are three places where MLFlow is introduced.
+
+
+### 1. MLProject
+The _MLProject_ is the file where both the entry-points and the executions environment is defined.
+
+The entry-points are used to specify a certain command and a set of parameters that can be 
+parametrized later on. These parameters can also be logged when tracking consecutive runs of
+the experiment so that each run is identified by the parameter values it used.
+
+In terms of the environment, MLFlow offer users 3 options: _Conda_, _Docker_ or _System_.
+Given that this project does not use Conda, and it is designed to run both in a developers machine,
+and a Yadage engine, the right option is to use the System environment (default).
+
+Check the [MLProject documentation][mlproject-docs] for further details.
+
+
+### 2. MLFlow CLI
+The MLFlow CLI is used within the shell scripts corresponding to the workflow steps that
+are going to be either parametrized or tracked.
+
+In the case of this project, those steps are:
+- [Training][script-train]: to parametrize.
+- [Evaluation][script-eval]: to track over time.
+
+On those shell scripts, the default Python script execution has been substitute by
+`mlflow run` command, specifying:
+
+- A certain experiment name.
+- Their corresponding `MLproject` entry-point.
+- The execution backend (local).
+- The execution environment (`--no-conda` = System).
+- Their set of parameters.
+
+Check the [MLFlow CLI documentation][mlflow-cli-docs] for further details.
+
+
+### 3. MLFlow Python library
+Finally, the `mlflow` Python package can be used within the Python scripts to define
+_tags_, _params_ or _artifacts_ that gets appended to the launched run.
+
+These elements would appear on the MLFlow _tracking server UI_, once the experiment runs
+finish, making the runs easily identifiable and comparable to each other.
+
+Check the [MLFlow tracking documentation][mlflow-track-docs] for further details.
+
+
+## Execution
+When running the workflow, you can specify the environment variable `MLFLOW_TRACKING_URI`
+to log the experiment runs information to a MLFlow tracking server previously deployed.
+
+To deploy the MLFlow tracking server locally:
+```shell script
+mlflow server
+```
+
+Depending on how the workflow is launched, a different tracking URI must be specified.
+There are actually two ways of executing the workflow:
+
+### A) Individual steps
+Individual steps can be launched using their shell script. Be aware their execution may depend on 
+previous step outputs, so a sequential order must be followed.
+
+Example:
+```shell script
+export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
+scripts/2_training.sh \
+    -p . \
+    -i workflow/input.yml \
+    -t .workdir/data/Samples_alice_0 \
+    -o .workdir
+```
+
+### B) Coordinated
+The full workflow can be launched using [Yadage][yadage-repo]. Yadage is a YAML specification language
+over a set of utilities that are used to coordinate workflows.
+
+In addition, as Yadage uses Docker images as execution environments to the workflow steps,
+the tracking server must be reachable from **within** the Docker container.
+
+Therefore:
+- Create experiments beforehand to avoid race conditions.
+- Define `host.docker.internal` as tracking server host.
+
+```shell script
+export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
+mlflow experiments create --experiment-name "madminer-ml-train"
+mlflow experiments create --experiment-name "madminer-ml-eval"
+export MLFLOW_TRACKING_URI=http://host.docker.internal:5000
+pip3 install yadage
+make yadage-run
+```
+
+
+[mlflow-website]: https://mlflow.org/
+[mlproject]: MLproject
+[mlflow-cli-docs]: https://www.mlflow.org/docs/latest/cli.html
+[mlflow-track-docs]: https://mlflow.org/docs/latest/tracking.html
+[mlproject-docs]: https://www.mlflow.org/docs/latest/projects.html
+[script-eval]: scripts/3_evaluation.sh
+[script-train]: scripts/2_training.sh

--- a/MLproject
+++ b/MLproject
@@ -1,0 +1,29 @@
+# ML Project:
+#
+# The following file specifies the project as a reproducible
+# MLFlow project, which allow us to parametrize the inputs on
+# consecutive runs and to track results using a tracking server.
+#
+# It has been created following this guide:
+# https://www.mlflow.org/docs/latest/projects.html
+
+name: madminer-workflow-ml
+
+entry_points:
+
+  train:
+    command: "python3 {project_path}/code/train.py {train_folder} {input_file} {output_dir}"
+    parameters:
+      project_path: path
+      input_file: path
+      train_folder: path
+      output_dir: path
+
+  eval:
+    command: "python3 {project_path}/code/evaluation.py {input_file} {model_dir} {data_file} {output_dir}"
+    parameters:
+      project_path: path
+      input_file: path
+      model_dir: path
+      data_file: path
+      output_dir: path

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ DOCKER_NAME=madminer-workflow-ml
 DOCKER_REGISTRY=madminertool
 DOCKER_VERSION=$(shell cat ./VERSION)
 
+MLFLOW_TRACKING_URI ?= "/tmp/mlflow"
+
 YADAGE_INPUT_DIR="$(PWD)/workflow"
 YADAGE_SPEC_DIR="$(PWD)/workflow/yadage"
 YADAGE_WORKDIR="$(PWD)/.yadage"
@@ -37,5 +39,6 @@ yadage-run: yadage-clean
 		-p data_file="/madminer/data/dummy_data.h5" \
 		-p input_file="input.yml" \
 		-p train_samples="1" \
+		-p mlflow_server=$(MLFLOW_TRACKING_URI) \
 		-d initdir=$(YADAGE_INPUT_DIR) \
 		--toplevel $(YADAGE_SPEC_DIR)

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ For debugging purposes, a dummy generated file is placed in the [data folder][da
 
 
 ## Workflow definition
-The workflow specification is composed of 3 hierarchical layers. From top to bottom:
+The workflow specification is composed of 4 hierarchical layers. From top to bottom:
 
 1. **Workflow spec:** description of how steps are coordinated.
 2. **Shell scripts:** entry points for each of the steps.
-3. **Python scripts:** set of actions to interact with Madminer.
+3. **MLproject rules:** entry point for parametrized steps.
+4. **Python scripts:** set of actions to interact with Madminer.
 
 The division into multiple layers is very useful for debugging. It provides developers an easy way 
 to test individual steps before testing the full workflow coordination.
@@ -49,6 +50,13 @@ Considering the workflow steps:
                         +--------------+
 
 
+## MLFlow
+For hyper-parameter tuning and models tracking, MLFlow has been introduced on certain parts
+of the workflow.
+
+Follow the [MLFlow guide][mlflow-guide] to review the implications.
+
+
 ## Execution
 When executing the workflow (either fully or some of its parts) it is important to consider that
 each individual step received inputs and generates outputs. Outputs are usually files, which need
@@ -75,7 +83,7 @@ scripts/1_sampling.sh \
     -o .workdir
 ```
 
-### B) Workflow
+### B) Coordinated
 The full workflow can be launched using [Yadage][yadage-repo]. Yadage is a YAML specification language
 over a set of utilities that are used to coordinate workflows. Please consider that it can be hard
 to define Yadage workflows as the [Yadage documentation][yadage-docs] is incomplete.
@@ -110,6 +118,7 @@ make push
 [madminer-docs]: https://madminer.readthedocs.io/en/latest/index.html
 [madminer-repo]: https://github.com/diana-hep/madminer
 [madminer-workflow-ph]: https://github.com/scailfin/madminer-workflow-ph
+[mlflow-guide]: MLFLOW.md
 [yadage-repo]: https://github.com/yadage/yadage
 [yadage-docs]: https://yadage.readthedocs.io/en/latest/
 [lukas-profile]: https://github.com/lukasheinrich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 h5py==2.10.0
 madminer==0.7.4
+mlflow==1.9.1
 numpy==1.18.3
 pyyaml==5.3.1

--- a/scripts/2_training.sh
+++ b/scripts/2_training.sh
@@ -49,5 +49,15 @@ mkdir -p "${MODEL_INFO_ABS_PATH}"
 
 
 # Perform actions
-python3 "${PROJECT_PATH}/code/train.py" "${TRAIN_FOLDER}" "${INPUT_FILE}" "${OUTPUT_DIR}"
+mlflow run \
+    --experiment-name "madminer-ml-train" \
+    --entry-point "train" \
+    --backend "local" \
+    --no-conda \
+    --param-list "project_path=${PROJECT_PATH}" \
+    --param-list "input_file=${INPUT_FILE}" \
+    --param-list "train_folder=${TRAIN_FOLDER}" \
+    --param-list "output_dir=${OUTPUT_DIR}" \
+    "${PROJECT_PATH}"
+
 tar -czvf "${MODEL_FILE_ABS_PATH}" -C "${MODEL_INFO_ABS_PATH}" .

--- a/scripts/3_evaluation.sh
+++ b/scripts/3_evaluation.sh
@@ -63,9 +63,20 @@ MODEL_NAME=$(find "${MODELS_ABS_PATH}" -type d -mindepth 1 -maxdepth 1 -exec bas
 MODEL_DIR="${MODELS_ABS_PATH}/${MODEL_NAME}"
 
 
-python3 "${PROJECT_PATH}/code/evaluation.py" "${INPUT_FILE}" "${MODEL_DIR}" "${DATA_FILE}" "${OUTPUT_DIR}"
+# Perform actions
+mlflow run \
+    --experiment-name "madminer-ml-eval" \
+    --entry-point "eval" \
+    --backend "local" \
+    --no-conda \
+    --param-list "project_path=${PROJECT_PATH}" \
+    --param-list "input_file=${INPUT_FILE}" \
+    --param-list "model_dir=${MODEL_DIR}" \
+    --param-list "data_file=${DATA_FILE}" \
+    --param-list "output_dir=${OUTPUT_DIR}" \
+    "${PROJECT_PATH}"
 
-tar -czvf "${OUTPUT_DIR}/Results_${MODEL_NAME}.tar.gz" \
+tar -czf "${OUTPUT_DIR}/Results_${MODEL_NAME}.tar.gz" \
     -C "${OUTPUT_DIR}" \
     "models" \
     "rates" \

--- a/workflow/yadage/steps.yml
+++ b/workflow/yadage/steps.yml
@@ -26,7 +26,9 @@ training:
   environment: *common_env_ml
   process:
     process_type: string-interpolated-cmd
-    cmd: scripts/2_training.sh -p /madminer -i {input_file} -t {train_folder} -o {output_dir}
+    cmd:
+        export MLFLOW_TRACKING_URI={mlflow_server} &&
+        scripts/2_training.sh -p /madminer -i {input_file} -t {train_folder} -o {output_dir}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: output_file
@@ -36,7 +38,9 @@ evaluating:
   environment: *common_env_ml
   process:
     process_type: string-interpolated-cmd
-    cmd: scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file} -o {output_dir}
+    cmd:
+        export MLFLOW_TRACKING_URI={mlflow_server} &&
+        scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file} -o {output_dir}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: output_files

--- a/workflow/yadage/workflow.yml
+++ b/workflow/yadage/workflow.yml
@@ -17,6 +17,7 @@ stages:
       scheduler_type: multistep-stage
       parameters:
         input_file: {step: init, output: input_file}
+        mlflow_server: {step: init, output: mlflow_server}
         train_folder: {step: sampling, output: sampling_file}
         output_dir: '{workdir}'
       scatter:
@@ -31,6 +32,7 @@ stages:
       parameters:
         data_file: {step: init, output: data_file}
         input_file: {step: init, output: input_file}
+        mlflow_server: {step: init, output: mlflow_server}
         model_file: {stages: training, output: output_file, unwrap: true}
         output_dir: '{workdir}'
       scatter:


### PR DESCRIPTION
This PR addresses issue https://github.com/scailfin/madminer-workflow/issues/22 creating a `MLproject` file, in addition to creating MLFlow documentation to correctly interact with its multiple pieces.

In a nutshell:

1. The `MLproject` file defines MLFlow runnable entry-points.
2. The `mlflow` Python package offers a CLI from which `MLproject` defined entry-points can be launched.
3. The `mlflow` Python package offers a CLI from which a _tracking server_ could be launched.
4. **[Not in PR]** The `mlflow` Python package serves a a library to attach tags or metrics to experiments run, so they can be later compared in the _tracking server_.

This is how the experiments run information look in the _tracking server_.

<img width="1325" alt="mlflow-experiments-ui" src="https://user-images.githubusercontent.com/6978377/87455991-992a2180-c606-11ea-90c4-ec5d91c26269.png">
