### PR TITLE
MLFlow tracking info

### DIFF
--- a/code/evaluation.py
+++ b/code/evaluation.py
@@ -268,7 +268,7 @@ for flag in include_xsec:
         hist_vars=[histogram_var],
     )
 
-    file_dir = f'{results_dir}'
+    file_dir = f'{rates_dir}'
     file_name = 'histo.npy' if flag else 'histo_kin.npy'
     file_path = f'{file_dir}/{file_name}'
 

--- a/code/evaluation.py
+++ b/code/evaluation.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import mlflow
 import numpy as np
 import os
 import sys
@@ -250,6 +251,38 @@ elif gen_method in score_estimator_methods:
 
 else:
     raise ValueError('Invalid generation method')
+
+
+#################################
+## MLFlow tracking information ##
+#################################
+
+mlflow.set_tags({
+    "context": "workflow",
+    "method": gen_method,
+})
+
+mlflow.log_params({
+    "asymptotic_limits": asymp_info,
+    "luminosity": luminosity,
+    "test split": test_split,
+})
+
+if gen_method in ratio_estimator_methods:
+    llr_means = np.mean(llr, axis=0)
+    mlflow.log_metrics({
+        "theta 0 LLR": llr_means[0],
+        "theta 1 LLR": llr_means[1],
+    })
+
+elif gen_method in score_estimator_methods:
+    score_means = np.mean(scores, axis=0)
+    mlflow.log_metrics({
+        "theta 0 score": score_means[0],
+        "theta 1 score": score_means[1],
+    })
+
+mlflow.log_artifacts(f'{results_dir}/{gen_method}')
 
 
 #################################

--- a/code/train.py
+++ b/code/train.py
@@ -41,18 +41,10 @@ valid_split = inputs['validation_split']
 ##### Perform training #####
 ############################
 
-score_estimator_methods = {'sally', 'sallino'}
 ratio_estimator_methods = {'alice', 'alices', 'cascal', 'carl', 'rolr', 'rascal'}
+score_estimator_methods = {'sally', 'sallino'}
 
-if method in score_estimator_methods:
-    estimator = ScoreEstimator()
-    estimator.train(
-        method=method,
-        x=samples_path + f'/x_{method}_train.npy',
-        t_xz=samples_path + f'/t_xz_{method}_train.npy',
-    )
-
-elif method in ratio_estimator_methods:
+if method in ratio_estimator_methods:
     estimator = ParameterizedRatioEstimator(n_hidden=(100, 100, 100))
     estimator.train(
         method=method,
@@ -65,6 +57,14 @@ elif method in ratio_estimator_methods:
         n_epochs=num_epochs,
         validation_split=valid_split,
         batch_size=batch_size,
+    )
+
+elif method in score_estimator_methods:
+    estimator = ScoreEstimator()
+    estimator.train(
+        method=method,
+        x=samples_path + f'/x_{method}_train.npy',
+        t_xz=samples_path + f'/t_xz_{method}_train.npy',
     )
 
 else:

--- a/code/train.py
+++ b/code/train.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import mlflow
 import os
 import sys
 import yaml
@@ -82,3 +83,22 @@ os.makedirs(model_folder_path, exist_ok=True)
 model_file_name = method
 model_file_path = f'{model_folder_path}/{model_file_name}'
 estimator.save(model_file_path)
+
+
+#################################
+## MLFlow tracking information ##
+#################################
+
+mlflow.set_tags({
+    "context": "workflow",
+    "method": method,
+})
+
+mlflow.log_params({
+    "alpha": alpha,
+    "batch size": batch_size,
+    "num. epochs": num_epochs,
+    "validation split": valid_split,
+})
+
+mlflow.log_artifacts(model_folder_path)

--- a/scripts/4_plotting.sh
+++ b/scripts/4_plotting.sh
@@ -41,7 +41,7 @@ mkdir -p "${OUTPUT_DIR}/plots"
 
 # POSIX shell scripts do not allow arrays (workaround)
 echo "${RESULT_FILES}" | tr ' ' '\n' | while read -r file; do
-    tar -xvf "${file}" -C "${OUTPUT_DIR}";
+    tar -xf "${file}" -C "${OUTPUT_DIR}";
 done
 
 python3 "${PROJECT_PATH}/code/plotting.py" "${INPUT_FILE}" "${OUTPUT_DIR}"


### PR DESCRIPTION
This PR addresses issue https://github.com/scailfin/madminer-workflow/issues/23 logging `training` and `evaluation` steps relevant information into an external MLFlow tracking server. 

This PR sits on top of two previously merged PRs:
- [MLFlow entry-point and docs](https://github.com/scailfin/madminer-workflow-ml/pull/1)
- [ML code simplification](https://github.com/scailfin/madminer-workflow-ml/pull/2)

---

### Example
Let's take a `evaluation` step run example:

**Its parameters:**

<img width="1050" alt="example params" src="https://user-images.githubusercontent.com/6978377/88039356-be0f1f00-cb47-11ea-8734-dc03cfb7d1e7.png">

**Its metrics:**

<img width="500" alt="examples metrics" src="https://user-images.githubusercontent.com/6978377/88039368-c10a0f80-cb47-11ea-9e84-d07106647e31.png">

**Its tags:**

<img width="500" alt="examples tags" src="https://user-images.githubusercontent.com/6978377/88039382-c5362d00-cb47-11ea-88f2-a3cfbf0f864b.png">

**Its artifacts:**

<img width="1000" alt="examples artifacts" src="https://user-images.githubusercontent.com/6978377/88039388-c7988700-cb47-11ea-8b49-74f8ca91a478.png">