### PR TITLE
MLFlow username definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DOCKER_NAME=madminer-workflow-ml
 DOCKER_REGISTRY=madminertool
 DOCKER_VERSION=$(shell cat ./VERSION)
 
+MLFLOW_USERNAME ?= $(shell whoami)
 MLFLOW_TRACKING_URI ?= "/tmp/mlflow"
 
 YADAGE_INPUT_DIR="$(PWD)/workflow"
@@ -42,5 +43,6 @@ yadage-run: yadage-clean
 		-p mlflow_args_t="\"''\"" \
 		-p mlflow_args_e="\"''\"" \
 		-p mlflow_server=$(MLFLOW_TRACKING_URI) \
+		-p mlflow_username=$(MLFLOW_USERNAME) \
 		-d initdir=$(YADAGE_INPUT_DIR) \
 		--toplevel $(YADAGE_SPEC_DIR)

--- a/workflow/yadage/steps.yml
+++ b/workflow/yadage/steps.yml
@@ -19,7 +19,7 @@ sampling:
     cmd:
       export USERNAME={mlflow_username} &&
       export MLFLOW_TRACKING_URI={mlflow_server} &&
-      scripts/1_sampling.sh -p /madminer -i {input_file} -d {data_file} -o {output_dir} -a {mlflow_args_s}
+      scripts/1_sampling.sh -p /madminer -i {input_file} -d {data_file} -o {output_dir} -a {mlflow_args}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: sampling_file
@@ -32,7 +32,7 @@ training:
     cmd:
       export USERNAME={mlflow_username} &&
       export MLFLOW_TRACKING_URI={mlflow_server} &&
-      scripts/2_training.sh -p /madminer -t {train_folder} -o {output_dir} -a {mlflow_args_t}
+      scripts/2_training.sh -p /madminer -t {train_folder} -o {output_dir} -a {mlflow_args}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: output_file
@@ -45,7 +45,7 @@ evaluating:
     cmd:
       export USERNAME={mlflow_username} &&
       export MLFLOW_TRACKING_URI={mlflow_server} &&
-      scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file} -o {output_dir} -a {mlflow_args_e}
+      scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file} -o {output_dir} -a {mlflow_args}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: output_files

--- a/workflow/yadage/steps.yml
+++ b/workflow/yadage/steps.yml
@@ -17,6 +17,7 @@ sampling:
   process:
     process_type: string-interpolated-cmd
     cmd:
+      export USERNAME={mlflow_username} &&
       export MLFLOW_TRACKING_URI={mlflow_server} &&
       scripts/1_sampling.sh -p /madminer -i {input_file} -d {data_file} -o {output_dir} -a {mlflow_args_s}
   publisher:
@@ -29,6 +30,7 @@ training:
   process:
     process_type: string-interpolated-cmd
     cmd:
+      export USERNAME={mlflow_username} &&
       export MLFLOW_TRACKING_URI={mlflow_server} &&
       scripts/2_training.sh -p /madminer -t {train_folder} -o {output_dir} -a {mlflow_args_t}
   publisher:
@@ -41,6 +43,7 @@ evaluating:
   process:
     process_type: string-interpolated-cmd
     cmd:
+      export USERNAME={mlflow_username} &&
       export MLFLOW_TRACKING_URI={mlflow_server} &&
       scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file} -o {output_dir} -a {mlflow_args_e}
   publisher:

--- a/workflow/yadage/workflow.yml
+++ b/workflow/yadage/workflow.yml
@@ -9,6 +9,7 @@ stages:
         input_file: {step: init, output: input_file}
         mlflow_args_s: {step: init, output: mlflow_args_s}
         mlflow_server: {step: init, output: mlflow_server}
+        mlflow_username: {step: init, output: mlflow_username}
         output_dir: '{workdir}'
       step: {$ref: 'steps.yml#/sampling'}
 
@@ -19,6 +20,7 @@ stages:
       parameters:
         mlflow_args_t: {step: init, output: mlflow_args_t}
         mlflow_server: {step: init, output: mlflow_server}
+        mlflow_username: {step: init, output: mlflow_username}
         train_folder: {step: sampling, output: sampling_file}
         output_dir: '{workdir}'
       scatter:
@@ -35,6 +37,7 @@ stages:
         input_file: {step: init, output: input_file}
         mlflow_args_e: {step: init, output: mlflow_args_e}
         mlflow_server: {step: init, output: mlflow_server}
+        mlflow_username: {step: init, output: mlflow_username}
         model_file: {stages: training, output: output_file, unwrap: true}
         output_dir: '{workdir}'
       scatter:

--- a/workflow/yadage/workflow.yml
+++ b/workflow/yadage/workflow.yml
@@ -7,7 +7,7 @@ stages:
       parameters:
         data_file: {step: init, output: data_file}
         input_file: {step: init, output: input_file}
-        mlflow_args_s: {step: init, output: mlflow_args_s}
+        mlflow_args: {step: init, output: mlflow_args_s}
         mlflow_server: {step: init, output: mlflow_server}
         mlflow_username: {step: init, output: mlflow_username}
         output_dir: '{workdir}'
@@ -18,7 +18,7 @@ stages:
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        mlflow_args_t: {step: init, output: mlflow_args_t}
+        mlflow_args: {step: init, output: mlflow_args_t}
         mlflow_server: {step: init, output: mlflow_server}
         mlflow_username: {step: init, output: mlflow_username}
         train_folder: {step: sampling, output: sampling_file}
@@ -35,7 +35,7 @@ stages:
       parameters:
         data_file: {step: init, output: data_file}
         input_file: {step: init, output: input_file}
-        mlflow_args_e: {step: init, output: mlflow_args_e}
+        mlflow_args: {step: init, output: mlflow_args_e}
         mlflow_server: {step: init, output: mlflow_server}
         mlflow_username: {step: init, output: mlflow_username}
         model_file: {stages: training, output: output_file, unwrap: true}


### PR DESCRIPTION
This PR fixes the execution of MLFlow experiment runs under certain scenarios.

The affected scenarios are those where the user executing a dockerized step of the workflow is not defined within the `/etc/passwd` file of the container file system, causing _MLFlow tracking_ to fail to identify who is running the experiment. [REANA](https://github.com/reanahub/reana) v0.7.0 is a good example: the user `reana` gets plugged in the `docker run` command, without being defined within the container that it runs.

As a solution, the user is specified in the `USERNAME` environment variable, catched by Python's [`getpass.getuser` function](https://docs.python.org/3.8/library/getpass.html#getpass.getuser), used internally by MLFlow.